### PR TITLE
refactor(backend): вынести генерацию документов из views.py в offer/services/ + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Quickoffer
-Application for quickly creating commercial proposals <br>
-Приложение для создания коммерческих документов в сфере СКС и формирования документов к ним <br>
-Ссылка - https://offerguru.ru/
+
+Application for quickly creating commercial proposals
+Приложение для создания коммерческих предложений в сфере СКС и формирования документов к ним
+
+Сайт — https://offerguru.ru/
 
 ## Технологии
 
@@ -14,24 +16,128 @@ Application for quickly creating commercial proposals <br>
 [![gunicorn](https://img.shields.io/badge/-gunicorn-464646?style=flat&logo=gunicorn&logoColor=56C0C0&color=65fa41)](https://gunicorn.org/)
 
 ## Возможности
-- Реализована регистрация и авторизация пользователей.
+
+- Регистрация и авторизация пользователей.
 - Создание клиентов индивидуальных для аккаунта.
 - Создание товаров индивидуальных для аккаунта.
 - Дополнительная информация в профиле (реквизиты).
 - Создание коммерческих предложений.
-- Реализован каталог популярных товаров.
-- Формирование документов (счет на работы, счет на товары, коммерческое предложение + характеристики, торг-12, договора)
+- Каталог популярных товаров.
+- Формирование документов (счёт на работы, счёт на товары, КП, КП + характеристики, ТОРГ-12, договоры).
+
+## Локальный запуск
+
+### Требования
+
+- Python 3.11+
+- Node.js 18+
+- PostgreSQL 14+
+
+### 1. Клонировать репозиторий
+
+```bash
+git clone <url>
+cd quickoffer
+```
+
+### 2. Бэкенд
+
+```bash
+cd backend
+
+# Создать виртуальное окружение
+python -m venv venv
+
+# Активировать
+# Windows:
+venv\Scripts\activate
+# Linux/Mac:
+source venv/bin/activate
+
+# Установить зависимости
+pip install -r requirements.txt
+
+# Настроить .env
+cp .env.example .env
+# Отредактировать .env — указать свои данные БД, SECRET_KEY, DEBUG_MODE=True
+# Пример:
+# POSTGRES_DB=quickoffer
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=mysecretpassword
+# DB_HOST=localhost
+# DB_PORT=5432
+# SECRET_KEY=your-secret-key
+# DEBUG_MODE=True
+
+# Применить миграции
+python manage.py migrate
+
+# Создать суперпользователя
+python manage.py createsuperuser
+
+# Запустить сервер
+python manage.py runserver
+```
+
+Бэкенд будет доступен на http://localhost:8000/
+
+### 3. Фронтенд
+
+```bash
+cd frontend
+
+# Установить зависимости
+npm install
+
+# Запустить dev-сервер
+npm start
+```
+
+Фронтенд будет доступен на http://localhost:3000/
+
+### Быстрый запуск (скрипты)
+
+В папке `infras/` лежат готовые скрипты для simultaneous запуска бэкенда и фронтенда (нужно прописать пути):
+
+**Windows:**
+```bash
+infras\run_qiuckoffer_win.bat
+```
+
+**Linux (Gnome Terminal):**
+```bash
+bash infras/quickoffer_linux.sh
+```
 
 ## Тестирование
 
 ```bash
-# Запуск всех тестов бэкенда
-cd backend && python manage.py test offer.tests --verbosity=2
+cd backend
+python manage.py test offer.tests --verbosity=2
 
-# Запуск конкретного файла
+# Конкретный файл
 python manage.py test offer.tests.test_models
 python manage.py test offer.tests.test_api_offers
 
-# Запуск конкретного тест-кейса
+# Конкретный тест-кейс
 python manage.py test offer.tests.test_api_offers.OfferAPITests
+```
+
+## Структура проекта
+
+```
+quickoffer/
+├── backend/
+│   ├── api/              # API endpoints (DRF)
+│   ├── offer/            # Основное приложение (модели, сервисы)
+│   │   ├── services/     # Бизнес-логика генерации документов
+│   │   └── tests/        # Тесты
+│   ├── quickoffer/       # Настройки Django
+│   ├── utils/            # Утилиты, шаблоны docx
+│   └── manage.py
+├── frontend/
+│   ├── public/
+│   ├── src/              # React-компоненты
+│   └── package.json
+└── infras/               # Скрипты для запуска
 ```

--- a/backend/api/v1/offer/views.py
+++ b/backend/api/v1/offer/views.py
@@ -1,10 +1,4 @@
 """API DRF OFFERS views - generate docs"""
-import os
-import io
-from datetime import datetime
-from django.http import HttpResponse
-from django.contrib.auth import get_user_model
-from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
@@ -12,17 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
 
-from docxtpl import DocxTemplate
-from docxtpl import InlineImage
-from docx.shared import Mm
-from quickoffer.settings import BASE_DIR
-
-from offer.models import (
-    OfferForCustomer,
-    OfferItems,
-    Profile,
-    Client
-)
+from offer.models import OfferForCustomer
 from api.filters import FilterForOffers
 from api.v1.offer.serializers import (
     OfferSerializer,
@@ -30,239 +14,15 @@ from api.v1.offer.serializers import (
     OfferFullSerializer,
     ChangeOfferStatusSerializer,
 )
-from utils.num_to_text import get_string_by_number, get_string_by_number_only
-from utils.helpers.string_helpers import (
-    read_company_type,
-    read_month_ru,
-    read_okei_type,
-    read_quantity_type
+from offer.services import (
+    generate_offer_doc,
+    generate_contract_items_doc,
+    generate_contract_service_doc,
+    generate_torg12,
+    generate_bill_work,
+    generate_bill_items,
 )
-
-User = get_user_model()
-
-
-def generate_dict_info_items(id, work=False):
-    """Генерирует словарь с общими данными."""
-
-    context = {}
-
-    # Дата сегодня
-    today = datetime.today().strftime('%d-%m-%Y')
-    context['date'] = today
-    context['now_day'] = datetime.today().strftime('%d')
-    context['now_month_ru'] = read_month_ru(int(datetime.today().strftime('%m')))
-    context['now_year'] = datetime.today().strftime('%Y')
-
-    # Блок данных
-    offer_id = get_object_or_404(OfferForCustomer, id=id)
-    items_all = OfferItems.objects.filter(
-        offer=offer_id
-    )
-    context['data_items'] = []
-    # Перебираем в табличку товары и услуги
-
-    count_items = 1
-    amount_items = 0
-    type = 'product'
-    for index, item in enumerate(items_all):
-        if work:
-            type = 'service'
-        if item.item.item_type == type:
-            context['data_items'].append({
-                'num': count_items,
-                'item': item.item,
-                'count': item.amount,
-                'quantity': read_quantity_type(str(item.item.quantity_type)),
-                'quantity_okei': read_okei_type(str(item.item.quantity_type)),
-                'category': str(item.item.group.last()),
-                'price': "{:.2f}".format(item.item_price_retail),
-                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
-            })
-            amount_items += item.amount
-            count_items += 1
-
-    context['count_items'] = count_items - 1
-    context['count_items_propis'] = get_string_by_number_only(count_items - 1)
-    context['amount_items'] = amount_items
-    context['summ'] = "{:.2f}".format(offer_id.final_price)
-    context['summ_devices'] = "{:.2f}".format(offer_id.final_price_goods)
-    context['summ_services'] = "{:.2f}".format(offer_id.final_price_work)
-    context['n_offer'] = f'{offer_id.id}'
-    context['propis'] = f'{get_string_by_number(offer_id.final_price)}, НДС не облагается'
-    context['propis_devices'] = f'{get_string_by_number(offer_id.final_price_goods)}, НДС не облагается'
-    context['propis_services'] = f'{get_string_by_number(offer_id.final_price_work)}, НДС не облагается'
-    context['reason'] = f'Договор №{offer_id.id} от {today}'
-
-    # Блок исполнитель
-    try:
-        installer = get_object_or_404(Profile, user=offer_id.author)
-        if installer.ruk: context['ruk'] = installer.ruk
-        context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
-        context['company_inn'] = installer.inn
-        context['company_ogrn'] = installer.ogrn
-        context['company_bik'] = installer.bik
-        context['company_kpp'] = installer.kpp
-        context['company_bank'] = installer.bank_name
-        context['company_bill'] = installer.bill_num
-        context['company_corr_bill'] = installer.bill_corr_num
-        context['company_address'] = installer.address_reg
-        context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name}, ИНН {installer.inn}, Адрес регистрации: {installer.address_reg}, Телефон:  {installer.phone}'
-        context['company_bank_full'] = f'р/с {installer.bill_num} в банке "{installer.bank_name}", БИК {installer.bik}, к/с {installer.bill_corr_num}'
-    except:
-        pass
-
-    # Блок клиент
-    try:
-        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
-        context['customer'] = f'{read_company_type(customer.company_type)} {customer.title}'
-        context['customer_inn'] = customer.inn
-        context['customer_address'] = customer.address_reg
-        context['customer_ogrn'] = customer.ogrn
-        context['customer_kpp'] = customer.kpp
-        context['customer_bank'] = customer.bank_name
-        context['customer_bill'] = customer.bill_num
-        context['customer_corr_bill'] = customer.bill_corr_num
-        context['customer_full'] = f'{read_company_type(customer.company_type)} {customer.title}, ИНН {customer.inn}, Адрес регистрации: {customer.address_reg}'
-        print("CUSTOMER", context['customer_full'])
-        context['customer_bank_full'] = f'р/с {customer.bill_num} в банке "{customer.bank_name}", БИК {customer.bik}, к/с {customer.bill_corr_num}'
-        print("CUSTOMER", context['customer_bank_full'])
-    except:
-        context['customer'] = 'Клиент не выбран'
-    return context
-
-def generate_offer_doc(id, description=False):
-    """генерация КП в формате doc, на основе ID коммерческого"""
-
-    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'offer_doc.docx')
-    doc = DocxTemplate(file)
-    context = {}
-
-    # Дата сегодня
-    today = datetime.today().strftime('%d-%m-%Y')
-
-    # Блок данных
-    offer_id = get_object_or_404(OfferForCustomer, id=id)
-    items_all = OfferItems.objects.filter(
-        offer=offer_id
-    )
-    context['data_items'] = []
-    context['data_services'] = []
-    # Перебираем в табличку товары и услуги
-
-    count_items = 1
-    count_services = 1
-    for item in items_all:
-        if item.item.item_type == 'product':
-            context['data_items'].append({
-                'num': count_items,
-                'item': str(item.item),
-                'brand': str(item.item.brand),
-                'category': str(item.item.group.last()),
-                'count': item.amount,
-                'quantity': read_quantity_type(str(item.item.quantity_type)),
-                'price': "{:.2f}".format(item.item_price_retail),
-                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
-            })
-            url_img = item.item.image
-            if url_img:
-                pass
-                image = InlineImage(doc, url_img, width=Mm(10))
-            else:
-                image = None
-            context['data_items'][-1]['image'] = image
-            if description:
-                context['data_items'][-1]['desc'] = str(item.item.description).replace('!', ': ').replace(';', '. ')
-                # Пример словаря характеристик для разбиения в таблице на будущее
-                # context['data_items'][-1]['desc'] = [{'desc_name': 'Тип', 'desc_param': 'Уличный'}, {'desc_name': 'Параметр', 'desc_param': '12В'}]
-            count_items += 1
-        if item.item.item_type == 'service':
-            context['data_services'].append({
-                'num': count_services,
-                'item': item.item,
-                'count': item.amount,
-                'quantity': read_quantity_type(str(item.item.quantity_type)),
-                'price': "{:.2f}".format(item.item_price_retail),
-                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
-            })
-            count_services += 1
-
-    context['summ'] = "{:.2f}".format(offer_id.final_price)
-    context['summ_devices'] = "{:.2f}".format(offer_id.final_price_goods)
-    context['summ_services'] = "{:.2f}".format(offer_id.final_price_work)
-    context['n_offer'] = f'{offer_id.id}'
-    context['propis'] = f'{get_string_by_number(offer_id.final_price)}, НДС не облагается'
-    context['date'] = today
-
-    # Блок исполнитель
-    installer = get_object_or_404(Profile, user=offer_id.author)
-    if installer.ruk: context['ruk'] = installer.ruk
-    context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
-    context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name} ИНН {installer.inn} Адрес регистрации: {installer.address_reg} Телефон:  {installer.phone}'
-
-    # Блок клиента
-    try:
-        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
-        context['customer'] = f'{read_company_type(customer.company_type)} {customer.title} ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
-    except:
-        pass
-
-    doc.render(context)
-    doc_io = io.BytesIO()
-    doc.save(doc_io)
-    doc_io.seek(0)
-
-    return doc_io
-
-
-def generate_contract_items_doc(id):
-    """Договор на товары."""
-
-    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'contract_items.docx')
-    doc = DocxTemplate(file)
-
-    # Блок данных
-    context = generate_dict_info_items(id)
-
-    doc.render(context)
-    doc_io = io.BytesIO()
-    doc.save(doc_io)
-    doc_io.seek(0)
-
-    return doc_io
-
-
-def generate_torg12(id):
-    """Накладная на товары."""
-
-    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'torg12.docx')
-    doc = DocxTemplate(file)
-
-    # Блок данных
-    context = generate_dict_info_items(id)
-
-    doc.render(context)
-    doc_io = io.BytesIO()
-    doc.save(doc_io)
-    doc_io.seek(0)
-
-    return doc_io
-
-
-def generate_contract_service_doc(id):
-    """Договор на работы."""
-
-    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'contract_work.docx')
-    doc = DocxTemplate(file)
-
-    # Блок данных
-    context = generate_dict_info_items(id, True)
-
-    doc.render(context)
-    doc_io = io.BytesIO()
-    doc.save(doc_io)
-    doc_io.seek(0)
-
-    return doc_io
+from offer.services.base import make_docx_response
 
 
 class OfferViewSet(viewsets.ModelViewSet):
@@ -275,232 +35,55 @@ class OfferViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         """Показываем только КП авторизованного пользователя"""
-
         user = self.request.user
-        queryset = OfferForCustomer.objects.filter(author=user)
-        return queryset
+        return OfferForCustomer.objects.filter(author=user)
 
     def get_serializer_class(self):
         """Определяем сериалайзер в зависимости от запроса"""
-
         if self.action in 'list':
             return OfferSerializer
         elif self.action in 'retrieve':
-            return  OfferFullSerializer
+            return OfferFullSerializer
         return OfferPostSerializer
 
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_bill_work(self, request, **kwargs):
-        """Скачивание счета на работы в формате doc"""
+        doc_io = generate_bill_work(kwargs['pk'])
+        return make_docx_response(doc_io, "generated_doc")
 
-        if request.method == 'GET':
-            file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'bill_work_wo_buh.docx')
-            doc = DocxTemplate(file)
-
-            # Дата сегодня
-            today = datetime.today().strftime('%d-%m-%Y')
-
-            # Блок данных
-            context = {}
-            offer_id = get_object_or_404(OfferForCustomer, id=kwargs['pk'])
-            context['summ'] = "{:.2f}".format(offer_id.final_price_work)
-            context['n_invoice'] = f'{offer_id.id}-2'
-            context['reason'] = f'Договор №{offer_id.id} от {today}'
-            context['propis'] = f'{get_string_by_number(offer_id.final_price_work)}, НДС не облагается'
-            context['date'] = today
-            context['info'] = f'Оплата по договору №{offer_id.id} от {today} за монтажные работы'
-            context['nds'] = 'Без НДС'
-
-            # Блок исполнитель
-            installer = get_object_or_404(Profile, user=offer_id.author)
-            context['bik'] = installer.bik
-            context['bank'] = installer.bank_name
-            context['bill_cor'] = installer.bill_corr_num
-            context['bill'] = installer.bill_num
-            context['inn'] = installer.inn
-            if installer.kpp: context['kpp'] = installer.kpp
-            if installer.ruk: context['ruk'] = installer.ruk
-            context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
-            context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name} ИНН {installer.inn} Адрес регистрации: {installer.address_reg} Телефон:  {installer.phone}'
-
-            # Блок клиента
-            try:
-                customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
-                context['customer'] = f'{read_company_type(customer.company_type)} {customer.title} ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
-            except:
-                pass
-
-            doc.render(context)
-            doc_io = io.BytesIO()  # create a file-like object
-            doc.save(doc_io)  # save data to file-like object
-            doc_io.seek(0)  # go to the beginning of the file-like object
-
-            response = HttpResponse(doc_io)
-
-            # Content-Disposition header makes a file downloadable
-            response["Content-Disposition"] = "attachment; filename=generated_doc"
-
-            # Set the appropriate Content-Type for docx file
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_bill_items(self, request, **kwargs):
-        """Скачивание счета на товары в формате doc"""
+        doc_io = generate_bill_items(kwargs['pk'])
+        return make_docx_response(doc_io, "offer_doc")
 
-        if request.method == 'GET':
-            file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'bill_items_wo_buh.docx')
-            doc = DocxTemplate(file)
-
-            # Дата сегодня
-            today = datetime.today().strftime('%d-%m-%Y')
-
-            # Блок данных
-            context = {}
-            offer_id = get_object_or_404(OfferForCustomer, id=kwargs['pk'])
-            items_all = OfferItems.objects.filter(
-                offer=offer_id
-            )
-            context['data'] = []
-            count_items = 0
-            # Перебираем в табличку товары
-            for index, item in enumerate(items_all):
-                if item.item.item_type == 'product':
-                    context['data'].append({
-                        'num': index + 1,
-                        'item': item.item,
-                        'count': item.amount,
-                        'price': "{:.2f}".format(item.item_price_retail),
-                        'summ': "{:.2f}".format(item.amount * item.item_price_retail)
-                    })
-                    count_items += 1
-
-            context['count_items'] = count_items
-            context['summ'] = "{:.2f}".format(offer_id.final_price_goods)
-            context['n_invoice'] = f'{offer_id.id}-1'
-            context['reason'] = f'Договор №{offer_id.id} от {today}'
-            context['propis'] = f'{get_string_by_number(offer_id.final_price_goods)}, НДС не облагается'
-            context['date'] = today
-            context['info'] = f'Оплата по договору №{offer_id.id} от {today} за монтажные работы'
-            context['nds'] = 'Без НДС'
-
-            # Блок исполнитель
-            installer = get_object_or_404(Profile, user=offer_id.author)
-            context['bik'] = installer.bik
-            context['bank'] = installer.bank_name
-            context['bill_cor'] = installer.bill_corr_num
-            context['bill'] = installer.bill_num
-            context['inn'] = installer.inn
-            if installer.kpp: context['kpp'] = installer.kpp
-            if installer.ruk: context['ruk'] = installer.ruk
-            context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
-            context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name} ИНН {installer.inn} Адрес регистрации: {installer.address_reg} Телефон:  {installer.phone}'
-
-            # context['data'] = [{'num': 0, 'item': 'hello', 'count': 2, 'price': 8000, 'summ': 16000}, {'num': 1, 'item': 'hello1', 'count': 2, 'price': 4000, 'summ': 8000}]
-            # Блок клиента
-            try:
-                customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
-                context['customer'] = f'{read_company_type(customer.company_type)} {customer.title} ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
-            except:
-                pass
-
-            doc.render(context)
-            doc_io = io.BytesIO()
-            doc.save(doc_io)
-            doc_io.seek(0)
-
-            response = HttpResponse(doc_io)
-
-            # Content-Disposition header makes a file downloadable
-            response["Content-Disposition"] = "attachment; filename=offer_doc"
-
-            # Set the appropriate Content-Type for docx file
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_doc(self, request, **kwargs):
-        """Скачивание КП в формате doc"""
+        doc_io = generate_offer_doc(kwargs['pk'])
+        return make_docx_response(doc_io, "generated_doc")
 
-        if request.method == 'GET':
-
-            doc_io = generate_offer_doc(kwargs['pk'])
-            response = HttpResponse(doc_io)
-            response["Content-Disposition"] = "attachment; filename=generated_doc"
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_doc_with_description(self, request, **kwargs):
-        """Скачивание КП в формате doc с характеристиками"""
+        doc_io = generate_offer_doc(kwargs['pk'], True)
+        return make_docx_response(doc_io, "generated_doc")
 
-        if request.method == 'GET':
-
-            doc_io = generate_offer_doc(kwargs['pk'], True)
-            response = HttpResponse(doc_io)
-            response["Content-Disposition"] = "attachment; filename=generated_doc"
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_contract_items(self, request, **kwargs):
-        """Скачивание договора на товары в формате doc"""
+        doc_io = generate_contract_items_doc(kwargs['pk'])
+        return make_docx_response(doc_io, "contract_doc")
 
-        if request.method == 'GET':
-
-            doc_io = generate_contract_items_doc(kwargs['pk'])
-            response = HttpResponse(doc_io)
-            response["Content-Disposition"] = "attachment; filename=contract_doc"
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_contract_service(self, request, **kwargs):
-        """Скачивание КП в формате doc"""
+        doc_io = generate_contract_service_doc(kwargs['pk'])
+        return make_docx_response(doc_io, "contract_doc")
 
-        if request.method == 'GET':
-
-            doc_io = generate_contract_service_doc(kwargs['pk'])
-            response = HttpResponse(doc_io)
-            response["Content-Disposition"] = "attachment; filename=contract_doc"
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-    @action(detail=True,
-            methods=['get'],
-            permission_classes=(AllowAny,))
+    @action(detail=True, methods=['get'], permission_classes=(AllowAny,))
     def download_torg12(self, request, **kwargs):
-        """Скачивание накладной торг-12 в формате doc"""
+        doc_io = generate_torg12(kwargs['pk'])
+        return make_docx_response(doc_io, "contract_doc")
 
-        if request.method == 'GET':
-
-            doc_io = generate_torg12(kwargs['pk'])
-            response = HttpResponse(doc_io)
-            response["Content-Disposition"] = "attachment; filename=contract_doc"
-            response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            return response
-
-    @action(detail=True,
-            methods=['patch'],
-            permission_classes=(IsAuthenticated,))
+    @action(detail=True, methods=['patch'], permission_classes=(IsAuthenticated,))
     def change_status(self, request, **kwargs):
         """Смена статуса КП."""
-
         offer = self.get_object()
         serializer = ChangeOfferStatusSerializer(
             offer,

--- a/backend/offer/services/__init__.py
+++ b/backend/offer/services/__init__.py
@@ -1,0 +1,4 @@
+from .offer_doc import generate_offer_doc
+from .contract import generate_contract_items_doc, generate_contract_service_doc
+from .torg12 import generate_torg12
+from .bill import generate_bill_work, generate_bill_items

--- a/backend/offer/services/base.py
+++ b/backend/offer/services/base.py
@@ -1,0 +1,25 @@
+import io
+import os
+
+from docxtpl import DocxTemplate
+from quickoffer.settings import BASE_DIR
+from django.http import HttpResponse
+
+
+def render_docx(template_name, context):
+    """Загружает шаблон, рендерит, возвращает BytesIO."""
+    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', template_name)
+    doc = DocxTemplate(file)
+    doc.render(context)
+    doc_io = io.BytesIO()
+    doc.save(doc_io)
+    doc_io.seek(0)
+    return doc_io
+
+
+def make_docx_response(doc_io, filename="generated_doc"):
+    """Оборачивает BytesIO в HttpResponse для скачивания."""
+    response = HttpResponse(doc_io)
+    response["Content-Disposition"] = f"attachment; filename={filename}"
+    response["Content-Type"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    return response

--- a/backend/offer/services/bill.py
+++ b/backend/offer/services/bill.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+
+from django.shortcuts import get_object_or_404
+
+from offer.models import OfferForCustomer, OfferItems, Profile, Client
+from offer.services.base import render_docx
+from utils.num_to_text import get_string_by_number
+from utils.helpers.string_helpers import read_company_type
+
+
+def generate_bill_work(id):
+    """Счёт на работы."""
+    today = datetime.today().strftime('%d-%m-%Y')
+    context = {}
+
+    offer_id = get_object_or_404(OfferForCustomer, id=id)
+    context['summ'] = "{:.2f}".format(offer_id.final_price_work)
+    context['n_invoice'] = f'{offer_id.id}-2'
+    context['reason'] = f'Договор №{offer_id.id} от {today}'
+    context['propis'] = f'{get_string_by_number(offer_id.final_price_work)}, НДС не облагается'
+    context['date'] = today
+    context['info'] = f'Оплата по договору №{offer_id.id} от {today} за монтажные работы'
+    context['nds'] = 'Без НДС'
+
+    installer = get_object_or_404(Profile, user=offer_id.author)
+    context['bik'] = installer.bik
+    context['bank'] = installer.bank_name
+    context['bill_cor'] = installer.bill_corr_num
+    context['bill'] = installer.bill_num
+    context['inn'] = installer.inn
+    if installer.kpp:
+        context['kpp'] = installer.kpp
+    if installer.ruk:
+        context['ruk'] = installer.ruk
+    context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
+    context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name} ИНН {installer.inn} Адрес регистрации: {installer.address_reg} Телефон:  {installer.phone}'
+
+    try:
+        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
+        context['customer'] = f'{read_company_type(customer.company_type)} {customer.title} ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
+    except Exception:
+        pass
+
+    return render_docx('bill_work_wo_buh.docx', context)
+
+
+def generate_bill_items(id):
+    """Счёт на товары."""
+    today = datetime.today().strftime('%d-%m-%Y')
+    context = {}
+
+    offer_id = get_object_or_404(OfferForCustomer, id=id)
+    items_all = OfferItems.objects.filter(
+        offer=offer_id
+    ).select_related('item')
+    context['data'] = []
+    count_items = 0
+    for index, item in enumerate(items_all):
+        if item.item.item_type == 'product':
+            context['data'].append({
+                'num': index + 1,
+                'item': item.item,
+                'count': item.amount,
+                'price': "{:.2f}".format(item.item_price_retail),
+                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
+            })
+            count_items += 1
+
+    context['count_items'] = count_items
+    context['summ'] = "{:.2f}".format(offer_id.final_price_goods)
+    context['n_invoice'] = f'{offer_id.id}-1'
+    context['reason'] = f'Договор №{offer_id.id} от {today}'
+    context['propis'] = f'{get_string_by_number(offer_id.final_price_goods)}, НДС не облагается'
+    context['date'] = today
+    context['info'] = f'Оплата по договору №{offer_id.id} от {today} за монтажные работы'
+    context['nds'] = 'Без НДС'
+
+    installer = get_object_or_404(Profile, user=offer_id.author)
+    context['bik'] = installer.bik
+    context['bank'] = installer.bank_name
+    context['bill_cor'] = installer.bill_corr_num
+    context['bill'] = installer.bill_num
+    context['inn'] = installer.inn
+    if installer.kpp:
+        context['kpp'] = installer.kpp
+    if installer.ruk:
+        context['ruk'] = installer.ruk
+    context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
+    context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name} ИНН {installer.inn} Адрес регистрации: {installer.address_reg} Телефон:  {installer.phone}'
+
+    try:
+        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
+        context['customer'] = f'{read_company_type(customer.company_type)} {customer.title} ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
+    except Exception:
+        pass
+
+    return render_docx('bill_items_wo_buh.docx', context)

--- a/backend/offer/services/context.py
+++ b/backend/offer/services/context.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+from offer.models import Client, Profile
+from utils.helpers.string_helpers import read_company_type, read_month_ru
+
+
+def get_date_context():
+    """Сегодняшняя дата в разных форматах."""
+    today = datetime.today().strftime('%d-%m-%Y')
+    return {
+        'date': today,
+        'now_day': datetime.today().strftime('%d'),
+        'now_month_ru': read_month_ru(int(datetime.today().strftime('%m'))),
+        'now_year': datetime.today().strftime('%Y'),
+    }
+
+
+def get_installer_context(profile):
+    """Реквизиты исполнителя из Profile."""
+    ctx = {
+        'company': f'{read_company_type(profile.company_type)} {profile.company_name}',
+        'company_inn': profile.inn,
+        'company_ogrn': profile.ogrn,
+        'company_bik': profile.bik,
+        'company_kpp': profile.kpp,
+        'company_bank': profile.bank_name,
+        'company_bill': profile.bill_num,
+        'company_corr_bill': profile.bill_corr_num,
+        'company_address': profile.address_reg,
+        'company_full': (
+            f'{read_company_type(profile.company_type)} {profile.company_name}, '
+            f'ИНН {profile.inn}, Адрес регистрации: {profile.address_reg}, '
+            f'Телефон: {profile.phone}'
+        ),
+        'company_bank_full': (
+            f'р/с {profile.bill_num} в банке "{profile.bank_name}", '
+            f'БИК {profile.bik}, к/с {profile.bill_corr_num}'
+        ),
+    }
+    if profile.ruk:
+        ctx['ruk'] = profile.ruk
+    return ctx
+
+
+def get_installer_short_context(profile):
+    """Короткие реквизиты для счетов (bik, bank, bill, inn, kpp, ruk)."""
+    ctx = {
+        'bik': profile.bik,
+        'bank': profile.bank_name,
+        'bill_cor': profile.bill_corr_num,
+        'bill': profile.bill_num,
+        'inn': profile.inn,
+        'company': f'{read_company_type(profile.company_type)} {profile.company_name}',
+        'company_full': (
+            f'{read_company_type(profile.company_type)} {profile.company_name} '
+            f'ИНН {profile.inn} Адрес регистрации: {profile.address_reg} '
+            f'Телефон: {profile.phone}'
+        ),
+    }
+    if profile.kpp:
+        ctx['kpp'] = profile.kpp
+    if profile.ruk:
+        ctx['ruk'] = profile.ruk
+    return ctx
+
+
+def get_customer_context(client):
+    """Реквизиты клиента из Client."""
+    ctx = {
+        'customer': f'{read_company_type(client.company_type)} {client.title}',
+        'customer_inn': client.inn,
+        'customer_address': client.address_reg,
+        'customer_ogrn': client.ogrn,
+        'customer_kpp': client.kpp,
+        'customer_bank': client.bank_name,
+        'customer_bill': client.bill_num,
+        'customer_corr_bill': client.bill_corr_num,
+        'customer_full': (
+            f'{read_company_type(client.company_type)} {client.title}, '
+            f'ИНН {client.inn}, Адрес регистрации: {client.address_reg}'
+        ),
+        'customer_bank_full': (
+            f'р/с {client.bill_num} в банке "{client.bank_name}", '
+            f'БИК {client.bik}, к/с {client.bill_corr_num}'
+        ),
+    }
+    return ctx

--- a/backend/offer/services/contract.py
+++ b/backend/offer/services/contract.py
@@ -1,0 +1,111 @@
+from datetime import datetime
+
+from django.shortcuts import get_object_or_404
+
+from offer.models import OfferForCustomer, OfferItems, Profile, Client
+from offer.services.base import render_docx
+from utils.num_to_text import get_string_by_number, get_string_by_number_only
+from utils.helpers.string_helpers import (
+    read_company_type, read_month_ru, read_quantity_type, read_okei_type
+)
+
+
+def generate_dict_info_items(id, work=False):
+    """Генерирует словарь с общими данными для договоров и накладных."""
+
+    context = {}
+
+    # Дата сегодня
+    today = datetime.today().strftime('%d-%m-%Y')
+    context['date'] = today
+    context['now_day'] = datetime.today().strftime('%d')
+    context['now_month_ru'] = read_month_ru(int(datetime.today().strftime('%m')))
+    context['now_year'] = datetime.today().strftime('%Y')
+
+    # Блок данных
+    offer_id = get_object_or_404(OfferForCustomer, id=id)
+    items_all = OfferItems.objects.filter(
+        offer=offer_id
+    ).select_related('item__brand', 'item').prefetch_related('item__group')
+    context['data_items'] = []
+
+    count_items = 1
+    amount_items = 0
+    type = 'product'
+    for index, item in enumerate(items_all):
+        if work:
+            type = 'service'
+        if item.item.item_type == type:
+            context['data_items'].append({
+                'num': count_items,
+                'item': item.item,
+                'count': item.amount,
+                'quantity': read_quantity_type(str(item.item.quantity_type)),
+                'quantity_okei': read_okei_type(str(item.item.quantity_type)),
+                'category': str(item.item.group.last()),
+                'price': "{:.2f}".format(item.item_price_retail),
+                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
+            })
+            amount_items += item.amount
+            count_items += 1
+
+    context['count_items'] = count_items - 1
+    context['count_items_propis'] = get_string_by_number_only(count_items - 1)
+    context['amount_items'] = amount_items
+    context['summ'] = "{:.2f}".format(offer_id.final_price)
+    context['summ_devices'] = "{:.2f}".format(offer_id.final_price_goods)
+    context['summ_services'] = "{:.2f}".format(offer_id.final_price_work)
+    context['n_offer'] = f'{offer_id.id}'
+    context['propis'] = f'{get_string_by_number(offer_id.final_price)}, НДС не облагается'
+    context['propis_devices'] = f'{get_string_by_number(offer_id.final_price_goods)}, НДС не облагается'
+    context['propis_services'] = f'{get_string_by_number(offer_id.final_price_work)}, НДС не облагается'
+    context['reason'] = f'Договор №{offer_id.id} от {today}'
+
+    # Блок исполнитель
+    try:
+        installer = get_object_or_404(Profile, user=offer_id.author)
+        if installer.ruk:
+            context['ruk'] = installer.ruk
+        context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
+        context['company_inn'] = installer.inn
+        context['company_ogrn'] = installer.ogrn
+        context['company_bik'] = installer.bik
+        context['company_kpp'] = installer.kpp
+        context['company_bank'] = installer.bank_name
+        context['company_bill'] = installer.bill_num
+        context['company_corr_bill'] = installer.bill_corr_num
+        context['company_address'] = installer.address_reg
+        context['company_full'] = f'{read_company_type(installer.company_type)} {installer.company_name}, ИНН {installer.inn}, Адрес регистрации: {installer.address_reg}, Телефон:  {installer.phone}'
+        context['company_bank_full'] = f'р/с {installer.bill_num} в банке "{installer.bank_name}", БИК {installer.bik}, к/с {installer.bill_corr_num}'
+    except Exception:
+        pass
+
+    # Блок клиент
+    try:
+        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
+        context['customer'] = f'{read_company_type(customer.company_type)} {customer.title}'
+        context['customer_inn'] = customer.inn
+        context['customer_address'] = customer.address_reg
+        context['customer_ogrn'] = customer.ogrn
+        context['customer_kpp'] = customer.kpp
+        context['customer_bank'] = customer.bank_name
+        context['customer_bill'] = customer.bill_num
+        context['customer_corr_bill'] = customer.bill_corr_num
+        context['customer_full'] = f'{read_company_type(customer.company_type)} {customer.title}, ИНН {customer.inn}, Адрес регистрации: {customer.address_reg}'
+        context['customer_bank_full'] = f'р/с {customer.bill_num} в банке "{customer.bank_name}", БИК {customer.bik}, к/с {customer.bill_corr_num}'
+    except Exception:
+        context['customer'] = 'Клиент не выбран'
+
+    return context
+
+
+def generate_contract_items_doc(id):
+    """Договор на товары."""
+    context = generate_dict_info_items(id)
+    return render_docx('contract_items.docx', context)
+
+
+def generate_contract_service_doc(id):
+    """Договор на работы."""
+    context = generate_dict_info_items(id, True)
+    return render_docx('contract_work.docx', context)

--- a/backend/offer/services/offer_doc.py
+++ b/backend/offer/services/offer_doc.py
@@ -1,0 +1,100 @@
+import os
+
+from datetime import datetime
+
+from django.shortcuts import get_object_or_404
+from docxtpl import DocxTemplate, InlineImage
+from docx.shared import Mm
+from quickoffer.settings import BASE_DIR
+
+from offer.models import OfferForCustomer, OfferItems, Profile, Client
+from utils.num_to_text import get_string_by_number
+from utils.helpers.string_helpers import read_company_type, read_quantity_type
+
+
+def generate_offer_doc(id, description=False):
+    """Генерация КП в формате doc, на основе ID коммерческого предложения."""
+
+    file = os.path.join(BASE_DIR, 'utils', 'doc_templates', 'offer_doc.docx')
+    doc = DocxTemplate(file)
+
+    today = datetime.today().strftime('%d-%m-%Y')
+    context = {}
+
+    # Блок данных
+    offer_id = get_object_or_404(OfferForCustomer, id=id)
+    items_all = OfferItems.objects.filter(
+        offer=offer_id
+    ).select_related('item__brand', 'item').prefetch_related('item__group')
+    context['data_items'] = []
+    context['data_services'] = []
+
+    count_items = 1
+    count_services = 1
+    for item in items_all:
+        if item.item.item_type == 'product':
+            context['data_items'].append({
+                'num': count_items,
+                'item': str(item.item),
+                'brand': str(item.item.brand),
+                'category': str(item.item.group.last()),
+                'count': item.amount,
+                'quantity': read_quantity_type(str(item.item.quantity_type)),
+                'price': "{:.2f}".format(item.item_price_retail),
+                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
+            })
+            url_img = item.item.image
+            if url_img:
+                pass
+                image = InlineImage(doc, url_img, width=Mm(10))
+            else:
+                image = None
+            context['data_items'][-1]['image'] = image
+            if description:
+                context['data_items'][-1]['desc'] = str(item.item.description).replace('!', ': ').replace(';', '. ')
+            count_items += 1
+        if item.item.item_type == 'service':
+            context['data_services'].append({
+                'num': count_services,
+                'item': item.item,
+                'count': item.amount,
+                'quantity': read_quantity_type(str(item.item.quantity_type)),
+                'price': "{:.2f}".format(item.item_price_retail),
+                'summ': "{:.2f}".format(item.amount * item.item_price_retail)
+            })
+            count_services += 1
+
+    context['summ'] = "{:.2f}".format(offer_id.final_price)
+    context['summ_devices'] = "{:.2f}".format(offer_id.final_price_goods)
+    context['summ_services'] = "{:.2f}".format(offer_id.final_price_work)
+    context['n_offer'] = f'{offer_id.id}'
+    context['propis'] = f'{get_string_by_number(offer_id.final_price)}, НДС не облагается'
+    context['date'] = today
+
+    # Блок исполнитель
+    installer = get_object_or_404(Profile, user=offer_id.author)
+    if installer.ruk:
+        context['ruk'] = installer.ruk
+    context['company'] = f'{read_company_type(installer.company_type)} {installer.company_name}'
+    context['company_full'] = (
+        f'{read_company_type(installer.company_type)} {installer.company_name} '
+        f'ИНН {installer.inn} Адрес регистрации: {installer.address_reg} '
+        f'Телефон: {installer.phone}'
+    )
+
+    # Блок клиента
+    try:
+        customer = get_object_or_404(Client, title=offer_id.name_client, author=offer_id.author)
+        context['customer'] = (
+            f'{read_company_type(customer.company_type)} {customer.title} '
+            f'ИНН {customer.inn} Адрес регистрации: {customer.address_reg}'
+        )
+    except Exception:
+        pass
+
+    doc.render(context)
+    import io
+    doc_io = io.BytesIO()
+    doc.save(doc_io)
+    doc_io.seek(0)
+    return doc_io

--- a/backend/offer/services/torg12.py
+++ b/backend/offer/services/torg12.py
@@ -1,0 +1,8 @@
+from offer.services.contract import generate_dict_info_items
+from offer.services.base import render_docx
+
+
+def generate_torg12(id):
+    """Накладная на товары."""
+    context = generate_dict_info_items(id)
+    return render_docx('torg12.docx', context)

--- a/backend/offer/tests/test_api_offers.py
+++ b/backend/offer/tests/test_api_offers.py
@@ -219,7 +219,7 @@ class OfferDocumentDownloadTests(BaseAPITest):
             item_price_purchase=8000.0,
         )
 
-    @patch('api.v1.offer.views.DocxTemplate')
+    @patch('offer.services.offer_doc.DocxTemplate')
     def test_download_doc(self, mock_docx):
         mock_instance = MagicMock()
         mock_docx.return_value = mock_instance
@@ -233,7 +233,7 @@ class OfferDocumentDownloadTests(BaseAPITest):
             response['Content-Type']
         )
 
-    @patch('api.v1.offer.views.DocxTemplate')
+    @patch('offer.services.base.DocxTemplate')
     def test_download_bill_items(self, mock_docx):
         mock_instance = MagicMock()
         mock_docx.return_value = mock_instance
@@ -243,7 +243,7 @@ class OfferDocumentDownloadTests(BaseAPITest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @patch('api.v1.offer.views.DocxTemplate')
+    @patch('offer.services.base.DocxTemplate')
     def test_download_contract_items(self, mock_docx):
         mock_instance = MagicMock()
         mock_docx.return_value = mock_instance
@@ -253,7 +253,7 @@ class OfferDocumentDownloadTests(BaseAPITest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @patch('api.v1.offer.views.DocxTemplate')
+    @patch('offer.services.base.DocxTemplate')
     def test_download_torg12(self, mock_docx):
         mock_instance = MagicMock()
         mock_docx.return_value = mock_instance


### PR DESCRIPTION
refactor(backend): вынести генерацию документов из views.py в offer/services/
- Создана структура offer/services/ с разделением по типу документа:
  base.py (render_docx, make_docx_response), offer_doc.py, contract.py,
  torg12.py, bill.py, context.py, __init__.py
- views.py сокращён с ~512 до 95 строк — только вызовы сервисов
- Добавлены select_related/prefetch_related во все запросы OfferItems
- Обновлены пути mock-патчей в тестах (api.v1.offer.views.DocxTemplate ->
  offer.services.offer_doc/base.DocxTemplate)

docs: добавить инструкцию по локальному запуску в README.md
Описаны требования, настройка БД, бэкенда (venv, pip, .env, migrate,
runserver), фронтенда (npm install, start), скрипты быстрого запуска.