### PR TITLE
feat: разделение 'Мои товары' на товары и услуги в каталоге

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ backups
 /backups/
 .backups
 .opencode/
+AGENTS.md
 
 .vscode
 

--- a/frontend/src/pages/site/catalog/Catalog.jsx
+++ b/frontend/src/pages/site/catalog/Catalog.jsx
@@ -41,6 +41,25 @@ const CatalogPage = ({ loginstate, onSignOut, user }) => {
         }
     }, [slug]);
 
+    useEffect(() => {
+        if (singleItem && listGroups.length > 0) {
+            const lastGroup = singleItem.group?.[singleItem.group.length - 1];
+            if (lastGroup) {
+                const foundInGroups = listGroups.find(g => g.id === lastGroup.id);
+                const foundInService = listService.find(s => s.id === lastGroup.id);
+                const found = foundInGroups || foundInService;
+
+                if (found) {
+                    setChosenCategory(found.id);
+                    setChosenTree(found.tree_id);
+                    setChosenTitle(found.title);
+                    setChosenDescription(found.description);
+                    setChosenType(foundInService ? 'service' : 'product');
+                }
+            }
+        }
+    }, [singleItem, listGroups, listService]);
+
     const loadSingleItem = async (itemSlug) => {
         setLoadingSingleItem(true);
         setItemError(null);
@@ -63,7 +82,7 @@ const CatalogPage = ({ loginstate, onSignOut, user }) => {
         group_api.getItemsGroup()
             .then(res => {
                 setListGroups(res);
-                if (res.length > 0 && chosenCategory == null) {
+                if (res.length > 0 && chosenCategory == null && !slug) {
                     setChosenCategory(res[0].id);
                     setChosenTree(res[0].tree_id);
                     setChosenTitle(res[0].title);
@@ -126,13 +145,24 @@ const CatalogPage = ({ loginstate, onSignOut, user }) => {
         });
     };
 
-    const selectMyItems = (e) => {
+    const selectMyProducts = (e) => {
         e.preventDefault();
         setChosenCategory(-1);
         setChosenTree(0);
         setChosenTitle('Мои товары');
         setChosenDescription('');
-        setChosenType(undefined);
+        setChosenType('product');
+        setSingleItem(null);
+        navigate('/catalog');
+    };
+
+    const selectMyServices = (e) => {
+        e.preventDefault();
+        setChosenCategory(-2);
+        setChosenTree(0);
+        setChosenTitle('Мои услуги');
+        setChosenDescription('');
+        setChosenType('service');
         setSingleItem(null);
         navigate('/catalog');
     };
@@ -171,9 +201,15 @@ const CatalogPage = ({ loginstate, onSignOut, user }) => {
                                 <div className="catalog-sidebar-divider" />
                                 <button
                                     className={`catalog-link ${-1 === chosenCategory ? 'active' : ''}`}
-                                    onClick={selectMyItems}
+                                    onClick={selectMyProducts}
                                 >
                                     Мои товары
+                                </button>
+                                <button
+                                    className={`catalog-link ${-2 === chosenCategory ? 'active' : ''}`}
+                                    onClick={selectMyServices}
+                                >
+                                    Мои услуги
                                 </button>
                             </>
                         )}

--- a/frontend/src/pages/site/items-area/ItemsArea.jsx
+++ b/frontend/src/pages/site/items-area/ItemsArea.jsx
@@ -49,8 +49,8 @@ const ItemsArea = ({ category_id, loginstate, title, description, item_type }) =
     if (loginstate === false) {
       getItems(page, categoryId, noBrands ? undefined : brands_id);
     } else {
-      if (categoryId === -1) {
-        getItemsOnlyUsers(page);
+      if (categoryId === -1 || categoryId === -2) {
+        getItemsOnlyUsers(page, item_type);
       } else {
         getItemsAuth(page, categoryId, noBrands ? undefined : brands_id);
       }
@@ -59,8 +59,8 @@ const ItemsArea = ({ category_id, loginstate, title, description, item_type }) =
 
   // === ЗАПРОСЫ К API ===
 
-  const getItemsOnlyUsers = (page) => {
-    items_api.getItemsUserPaginate({ page, status: '' })
+  const getItemsOnlyUsers = (page, item_type) => {
+    items_api.getItemsUserPaginate({ page, status: item_type || '' })
       .then(res => {
         setpageCount(Math.ceil(res.count / 8));
         setListItems(res.results);
@@ -189,7 +189,19 @@ const ItemsArea = ({ category_id, loginstate, title, description, item_type }) =
                 type="button"
               >
                 <Plus size={16} className="me-2" />
-                Добавить
+                Добавить товар
+              </button>
+            </div>
+          )}
+          {category_id === -2 && (
+            <div className="col-6 p-0">
+              <button
+                onClick={CreateItem}
+                className="btn btn-primary btn-create-small"
+                type="button"
+              >
+                <Plus size={16} className="me-2" />
+                Добавить услугу
               </button>
             </div>
           )}


### PR DESCRIPTION
- Сайдбар: две кнопки 'Мои товары' (item_type=product) и 'Мои услуги' (item_type=service)
- ItemsArea: передача item_type в API /api/itemsuser/?item_type=...
- Кнопка 'Добавить' дублируется для товаров и услуг
- .gitignore: добавлен AGENTS.md
- Catalog: баг-фикс: useEffect для singleItem, !slug в getGroups