### PR TITLE
feat: каталог - поиск товаров с модалкой + фикс приватности

### DIFF
--- a/backend/api/filters.py
+++ b/backend/api/filters.py
@@ -15,9 +15,9 @@ class FilterForClients(FilterSet):
 
 
 class FilterForItems(FilterSet):
-    """Поиск по товарам-услугам по вхождению в начало названия"""
+    """Поиск по товарам-услугам по вхождению в название"""
 
-    item = filters.CharFilter(field_name='title', lookup_expr='startswith')
+    item = filters.CharFilter(field_name='title', lookup_expr='icontains')
 
     class Meta:
         model = Item

--- a/backend/api/v1/items/views.py
+++ b/backend/api/v1/items/views.py
@@ -2,6 +2,7 @@
 from rest_framework import viewsets
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
@@ -21,7 +22,7 @@ User = get_user_model()
 
 class ItemDetailView(RetrieveAPIView):
     """Получение одного публичного товара по ID"""
-    queryset = Item.objects.filter(private_type=False)
+    queryset = Item.objects.filter(private_type=False, is_deleted=False)
     serializer_class = ItemSingleSerializer
     permission_classes = (AllowAny,)
     lookup_field = 'slug'
@@ -55,7 +56,7 @@ class ItemUserViewSet(viewsets.ModelViewSet):
 class ItemViewSet(viewsets.ModelViewSet):
     """Апи вьюсет для категорий товаров и услуг."""
 
-    queryset = Item.objects.filter(private_type=False)
+    queryset = Item.objects.filter(private_type=False, is_deleted=False)
     serializer_class = ItemSerializer
     permission_classes = (IsAdminOrReadOnly,)
     filter_backends = (DjangoFilterBackend, OrderingFilter)
@@ -66,7 +67,7 @@ class ItemViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Выделяем бренды, переданные в запросе"""
 
-        queryset_general_items = Item.objects.filter(private_type=False)
+        queryset_general_items = Item.objects.filter(private_type=False, is_deleted=False)
         if 'brand' in self.request.GET:
             ids = self.request.GET.get('brand')
             if not ids:
@@ -93,7 +94,7 @@ class ItemViewSetAuth(viewsets.ModelViewSet):
     def get_queryset(self):
         """Выделяем бренды, переданные в запросе"""
 
-        queryset_general_items = Item.objects.filter(private_type=False)
+        queryset_general_items = Item.objects.filter(private_type=False, is_deleted=False)
         if 'brand' in self.request.GET:
             ids = self.request.GET.get('brand')
             if not ids:
@@ -110,9 +111,32 @@ class ItemViewSetAuth(viewsets.ModelViewSet):
 class ItemFinderViewSet(viewsets.ReadOnlyModelViewSet):
     """Поиск по товарам."""
 
-    queryset = Item.objects.all()
+    queryset = Item.objects.filter(is_deleted=False, private_type=False)
     serializer_class = ItemSerializer
     permission_classes = (IsAdminOrReadOnly,)
     pagination_class = None
     filter_backends = (DjangoFilterBackend, )
     filterset_class = FilterForItems
+
+    def list(self, request, *args, **kwargs):
+        public_items = list(self.filter_queryset(self.get_queryset()))
+
+        if request.user.is_authenticated:
+            user_items = ItemUser.objects.filter(
+                author=request.user,
+                is_deleted=False
+            )
+            search_query = request.query_params.get('item', '')
+            if search_query:
+                user_items = user_items.filter(title__icontains=search_query)
+            public_items.extend(list(user_items))
+
+        seen = set()
+        unique = []
+        for item in public_items:
+            if item.id not in seen:
+                seen.add(item.id)
+                unique.append(item)
+
+        serializer = self.get_serializer(unique, many=True)
+        return Response(serializer.data)

--- a/backend/offer/tests/test_api_finder.py
+++ b/backend/offer/tests/test_api_finder.py
@@ -1,0 +1,143 @@
+"""Tests for items finder (search) API endpoint."""
+from django.contrib.auth.models import User
+from rest_framework import status
+
+from offer.models import Brand, Item, ItemUser
+from offer.tests.base import BaseAPITest
+
+
+class ItemFinderUnauthTests(BaseAPITest):
+    """Поиск без авторизации — только публичные товары."""
+
+    def setUp(self):
+        super().setUp()
+        self.client.credentials()
+        self.public = Item.objects.create(
+            title='Камера DS-2CD2147G2-L',
+            price_retail=8500.0,
+            private_type=False,
+        )
+        self.private_other = Item.objects.create(
+            title='Камера DH-IPC-HFW1439T1P-A-IL',
+            price_retail=5000.0,
+            private_type=True,
+        )
+
+    def test_unauth_sees_only_public(self):
+        response = self.client.get('/api/itemsfinder/?item=Камера')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [i['title'] for i in response.data]
+        self.assertIn('Камера DS-2CD2147G2-L', titles)
+        self.assertNotIn('Камера DH-IPC-HFW1439T1P-A-IL', titles)
+
+    def test_unauth_no_user_items(self):
+        user2 = User.objects.create_user(
+            username='other', password='testpass123'
+        )
+        ItemUser.objects.create(
+            title='Мой приватный товар',
+            price_retail=100.0,
+            private_type=True,
+            author=user2,
+        )
+        response = self.client.get('/api/itemsfinder/?item=Мой')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+    def test_unauth_no_deleted_items(self):
+        Item.objects.create(
+            title='Удалённая камера',
+            price_retail=3000.0,
+            private_type=False,
+            is_deleted=True,
+        )
+        response = self.client.get('/api/itemsfinder/?item=Удалённая')
+        self.assertEqual(len(response.data), 0)
+
+
+class ItemFinderAuthTests(BaseAPITest):
+    """Поиск с авторизацией — публичные + свои приватные."""
+
+    def setUp(self):
+        super().setUp()
+        self.other_user = User.objects.create_user(
+            username='other', password='testpass123'
+        )
+        self.public = Item.objects.create(
+            title='Камера DS-2CD2147G2-L',
+            price_retail=8500.0,
+            private_type=False,
+        )
+        self.my_item = ItemUser.objects.create(
+            title='Мой приватный товар',
+            price_retail=2500.0,
+            private_type=True,
+            author=self.user,
+        )
+        self.other_item = ItemUser.objects.create(
+            title='Чужой приватный товар',
+            price_retail=3000.0,
+            private_type=True,
+            author=self.other_user,
+        )
+
+    def test_auth_sees_public_items(self):
+        response = self.client.get('/api/itemsfinder/?item=Камера')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [i['title'] for i in response.data]
+        self.assertIn('Камера DS-2CD2147G2-L', titles)
+
+    def test_auth_sees_own_private_items(self):
+        response = self.client.get('/api/itemsfinder/?item=Мой')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [i['title'] for i in response.data]
+        self.assertIn('Мой приватный товар', titles)
+
+    def test_auth_does_not_see_other_private_items(self):
+        response = self.client.get('/api/itemsfinder/?item=Чужой')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+    def test_auth_combined_results(self):
+        """Публичные + свои приватные в одном запросе."""
+        response = self.client.get('/api/itemsfinder/?item=')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [i['title'] for i in response.data]
+        self.assertIn('Камера DS-2CD2147G2-L', titles)
+        self.assertIn('Мой приватный товар', titles)
+        self.assertNotIn('Чужой приватный товар', titles)
+
+    def test_auth_no_deleted_items(self):
+        ItemUser.objects.create(
+            title='Мой удалённый товар',
+            price_retail=100.0,
+            private_type=True,
+            is_deleted=True,
+            author=self.user,
+        )
+        response = self.client.get('/api/itemsfinder/?item=Мой удалённый')
+        titles = [i['title'] for i in response.data]
+        self.assertNotIn('Мой удалённый товар', titles)
+
+    def test_search_contains(self):
+        """Поиск по вхождению в название (contains)."""
+        Item.objects.create(
+            title='Кабель UTP Cat5e',
+            price_retail=200.0,
+            private_type=False,
+        )
+        response = self.client.get('/api/itemsfinder/?item=UTP')
+        titles = [i['title'] for i in response.data]
+        self.assertIn('Кабель UTP Cat5e', titles)
+        self.assertNotIn('Камера DS-2CD2147G2-L', titles)
+
+    def test_no_duplicates(self):
+        """Один товар не дублируется в выдаче."""
+        response = self.client.get('/api/itemsfinder/?item=Камера')
+        titles = [i['title'] for i in response.data]
+        self.assertEqual(titles.count('Камера DS-2CD2147G2-L'), 1)
+
+    def test_empty_query_returns_all(self):
+        response = self.client.get('/api/itemsfinder/?item=')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(response.data), 2)

--- a/frontend/src/api/items_api/index.js
+++ b/frontend/src/api/items_api/index.js
@@ -202,7 +202,8 @@ class ApiItems {
       {
         method: 'GET',
         headers: {
-          ...this._headers
+          ...this._headers,
+          ...(token && { 'authorization': `Token ${token}` })
         }
       }
     ).then(this.checkResponse)

--- a/frontend/src/components/catalog-search/CatalogSearch.jsx
+++ b/frontend/src/components/catalog-search/CatalogSearch.jsx
@@ -1,0 +1,147 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search, ShoppingBag } from 'react-feather';
+import items_api from '../../api/items_api';
+import CartPlusItem from '../../utils/items/cartPlusItem';
+import CheckSameCartItem from '../../utils/items/checkSameCartItem';
+import './catalogSearch.css';
+
+const CatalogSearch = () => {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState([]);
+    const [isOpen, setIsOpen] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const wrapperRef = useRef(null);
+    const debounceRef = useRef(null);
+    const navigate = useNavigate();
+
+    let items = [];
+    try {
+        items = JSON.parse(localStorage.getItem('items')) || [];
+    } catch { }
+
+    const search = useCallback((value) => {
+        if (!value || value.length < 1) {
+            setResults([]);
+            setIsOpen(false);
+            return;
+        }
+        setLoading(true);
+        items_api.findItem({ item: value })
+            .then(res => {
+                setResults(res.slice(0, 5));
+                setIsOpen(true);
+            })
+            .catch(() => {
+                setResults([]);
+                setIsOpen(false);
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    const handleChange = (e) => {
+        const value = e.target.value;
+        setQuery(value);
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => search(value), 300);
+    };
+
+    const handleAddToCart = (item, e) => {
+        e.stopPropagation();
+        const currentItems = JSON.parse(localStorage.getItem('items')) || [];
+        if (!CheckSameCartItem(item.id, currentItems)) {
+            CartPlusItem(item, currentItems, e);
+        }
+        setIsOpen(false);
+        setQuery('');
+    };
+
+    const handleItemClick = (slug) => {
+        navigate(`/catalog/${slug}`);
+        setIsOpen(false);
+        setQuery('');
+    };
+
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
+    }, []);
+
+    const formatPrice = (price) => {
+        if (!price) return '';
+        return Number(price).toLocaleString('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 });
+    };
+
+    return (
+        <div className="catalog-search" ref={wrapperRef}>
+            <div className="catalog-search-wrap">
+                <Search size={15} className="catalog-search-icon" />
+                <input
+                    className="catalog-search-input"
+                    type="text"
+                    placeholder="Найти товар..."
+                    value={query}
+                    onChange={handleChange}
+                    onFocus={() => results.length > 0 && setIsOpen(true)}
+                />
+                {loading && <span className="catalog-search-spinner" />}
+            </div>
+
+            {isOpen && results.length > 0 && (
+                <div className="catalog-search-dropdown">
+                    {results.map(item => {
+                        const inCart = CheckSameCartItem(item.id, items);
+                        const title = item.brand ? `${item.title} ${item.brand}` : item.title;
+                        return (
+                            <div
+                                key={item.id}
+                                className="catalog-search-item"
+                                onClick={() => handleItemClick(item.slug)}
+                            >
+                                {item.image && (
+                                    <img
+                                        className="catalog-search-item-img"
+                                        src={item.image}
+                                        alt={title}
+                                    />
+                                )}
+                                <div className="catalog-search-item-info">
+                                    <span className="catalog-search-item-title">{title}</span>
+                                    {item.price_retail && (
+                                        <span className="catalog-search-item-price">{formatPrice(item.price_retail)}</span>
+                                    )}
+                                </div>
+                                <button
+                                    className={`catalog-search-cart-btn ${inCart ? 'in-cart' : ''}`}
+                                    onClick={(e) => handleAddToCart(item, e)}
+                                    title={inCart ? 'Уже в корзине' : 'Добавить в корзину'}
+                                >
+                                    <ShoppingBag size={14} />
+                                </button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {isOpen && query && results.length === 0 && !loading && (
+                <div className="catalog-search-dropdown">
+                    <div className="catalog-search-empty">Ничего не найдено</div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default CatalogSearch;

--- a/frontend/src/components/catalog-search/catalogSearch.css
+++ b/frontend/src/components/catalog-search/catalogSearch.css
@@ -1,0 +1,153 @@
+.catalog-search {
+    position: relative;
+    padding: 0 2px;
+}
+
+.catalog-search-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.catalog-search-icon {
+    position: absolute;
+    left: 10px;
+    color: #5a5e72;
+    pointer-events: none;
+}
+
+.catalog-search-input {
+    width: 100%;
+    height: 36px;
+    padding: 0 32px 0 32px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.06);
+    color: #e0e2eb;
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.2s, background 0.2s;
+    box-sizing: border-box;
+}
+
+.catalog-search-input::placeholder {
+    color: #5a5e72;
+}
+
+.catalog-search-input:focus {
+    border-color: #5c61f2;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.catalog-search-spinner {
+    position: absolute;
+    right: 10px;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-top-color: #5c61f2;
+    border-radius: 50%;
+    animation: catalog-spin 0.6s linear infinite;
+}
+
+@keyframes catalog-spin {
+    to { transform: rotate(360deg); }
+}
+
+.catalog-search-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    right: 0;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+    z-index: 1100;
+    overflow: hidden;
+}
+
+.catalog-search-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+.catalog-search-item:hover {
+    background: #f5f6fa;
+}
+
+.catalog-search-item-img {
+    width: 36px;
+    height: 36px;
+    border-radius: 6px;
+    object-fit: cover;
+    flex-shrink: 0;
+    background: #f0f1f5;
+}
+
+.catalog-search-item-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.catalog-search-item-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: #1a1d2e;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.catalog-search-item-price {
+    font-size: 12px;
+    color: #5a5e72;
+    font-weight: 500;
+}
+
+.catalog-search-cart-btn {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border: 1px solid #e8ecf4;
+    border-radius: 8px;
+    background: #fff;
+    color: #5c61f2;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+}
+
+.catalog-search-cart-btn:hover {
+    background: #5c61f2;
+    color: #fff;
+    border-color: #5c61f2;
+}
+
+.catalog-search-cart-btn.in-cart {
+    background: #f0f0ff;
+    border-color: #5c61f2;
+    color: #5c61f2;
+}
+
+.catalog-search-empty {
+    text-align: center;
+    padding: 20px 12px;
+    color: #8b8fa3;
+    font-size: 13px;
+}
+
+@media (max-width: 767.98px) {
+    .catalog-search-dropdown {
+        max-height: 50dvh;
+        overflow-y: auto;
+    }
+}

--- a/frontend/src/pages/site/catalog/Catalog.jsx
+++ b/frontend/src/pages/site/catalog/Catalog.jsx
@@ -9,6 +9,7 @@ import ItemCard from '../items-area/ItemCard.jsx';
 
 import group_api from '../../../api/group_api';
 import { AlignJustify, X, Menu } from 'react-feather';
+import CatalogSearch from '../../../components/catalog-search/CatalogSearch';
 import './styles.css'
 
 
@@ -185,6 +186,8 @@ const CatalogPage = ({ loginstate, onSignOut, user }) => {
                 {sidebarOpen && <div className="catalog-sidebar-overlay" onClick={() => setSidebarOpen(false)} />}
                 <aside className={`catalog-sidebar ${sidebarOpen ? 'open' : ''}`}>
                     <div className="catalog-sidebar-inner">
+                        <CatalogSearch />
+                        <div className="catalog-sidebar-divider" />
                         <span className="catalog-sidebar-heading"><Menu size={14} /> Категории</span>
                         {renderTree(listGroups, 'g')}
 


### PR DESCRIPTION
- CatalogSearch: инпут в сайдбаре каталога с топ-5 результатами
- Добавление в корзину прямо из модалки, навигация на страницу товара
- Бэкенд: ItemFinderViewSet фильтрует is_deleted + private_type
- Авторизованные видят свои приватные ItemUser в поиске
- findItem на фронте теперь отправляет токен авторизации
- Поиск по вхождению (icontains) вместо начала названия
- 11 новых тестов на поиск (test_api_finder)